### PR TITLE
Load autoscaler configuration file correctly in deploy script

### DIFF
--- a/infra/.#build.sh
+++ b/infra/.#build.sh
@@ -1,0 +1,1 @@
+swnelson@swnelson-laptop.11282:1629218661

--- a/infra/.#build.sh
+++ b/infra/.#build.sh
@@ -1,1 +1,0 @@
-swnelson@swnelson-laptop.11282:1629218661

--- a/infra/autoscaler/update.sh
+++ b/infra/autoscaler/update.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -xeuo pipefail
 
+echo "Checking for existing autoscaler..."
+if gcloud compute instances list --zones=us-west1-a | grep -q 'thor-autoscaler-production'; then
 
-echo "Bringing down existing autoscaler..."
-gcloud compute instances delete thor-autoscaler-production \
-       --zone=us-west1-a
 
-echo "Bringing up new one..."
+    echo "Bringing down existing autoscaler..."
+    gcloud compute instances delete thor-autoscaler-production \
+           --zone=us-west1-a
+fi
+
+echo "Bringing up new autoscaler..."
 
 # Create the autoscaler using the configuration file ('production-cloudconfig')
 # in the same directory as this script.

--- a/infra/autoscaler/update.sh
+++ b/infra/autoscaler/update.sh
@@ -2,8 +2,6 @@
 set -xeuo pipefail
 
 
-cd "${SCRIPT_DIR}/../"
-
 echo "Bringing down existing autoscaler..."
 gcloud compute instances delete thor-autoscaler-production \
        --zone=us-west1-a

--- a/infra/autoscaler/update.sh
+++ b/infra/autoscaler/update.sh
@@ -3,8 +3,6 @@ set -xeuo pipefail
 
 echo "Checking for existing autoscaler..."
 if gcloud compute instances list --zones=us-west1-a | grep -q 'thor-autoscaler-production'; then
-
-
     echo "Bringing down existing autoscaler..."
     gcloud compute instances delete thor-autoscaler-production \
            --zone=us-west1-a

--- a/infra/autoscaler/update.sh
+++ b/infra/autoscaler/update.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 set -xeuo pipefail
 
+
+cd "${SCRIPT_DIR}/../"
+
 echo "Bringing down existing autoscaler..."
 gcloud compute instances delete thor-autoscaler-production \
        --zone=us-west1-a
 
 echo "Bringing up new one..."
+
+# Create the autoscaler using the configuration file ('production-cloudconfig')
+# in the same directory as this script.
+#
+# Magic one-liner to get the directory containing this script:
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# Now we can get the path of the config file:
+CONFIG_FILE=${SCRIPT_DIR}/production-cloudconfig
+
 gcloud compute instances create thor-autoscaler-production \
        --description="THOR autoscaler for the production queue" \
        --machine-type=e2-small \
@@ -13,4 +25,4 @@ gcloud compute instances create thor-autoscaler-production \
        --zone=us-west1-a \
        --scopes=cloud-platform \
        --create-disk='image-family=projects/cos-cloud/global/images/family/cos-stable,boot=yes,auto-delete=yes' \
-       --metadata-from-file=user-data=production-cloudconfig
+       --metadata-from-file=user-data=${CONFIG_FILE}


### PR DESCRIPTION
This is why the autoscaler was missing. The CD script failed:
https://github.com/B612-Asteroid-Institute/thorctl/runs/3342363313

>>> 
```
Run infra/autoscaler/update.sh
+ echo 'Bringing down existing autoscaler...'
+ gcloud compute instances delete thor-autoscaler-production --zone=us-west1-a
Bringing down existing autoscaler...
The following instances will be deleted. Any attached disks configured
 to be auto-deleted will be deleted unless they are attached to any 
other instances or the `--keep-disks` flag is given and specifies them
 for keeping. Deleting a disk is irreversible and any data on the disk
 will be lost.
 - [thor-autoscaler-production] in [us-west1-a]

Do you want to continue (Y/n)?  
Deleted [https://www.googleapis.com/compute/v1/projects/***/zones/us-west1-a/instances/thor-autoscaler-production].
+ echo 'Bringing up new one...'
Bringing up new one...
+ gcloud compute instances create thor-autoscaler-production '--description=THOR autoscaler for the production queue' --machine-type=e2-small --service-account=thor-autoscaler@***.iam.gserviceaccount.com --zone=us-west1-a --scopes=cloud-platform --create-disk=image-family=projects/cos-cloud/global/images/family/cos-stable,boot=yes,auto-delete=yes --metadata-from-file=user-data=production-cloudconfig
ERROR: (gcloud.compute.instances.create) Unable to read file [production-cloudconfig]: [Errno 2] No such file or directory: 'production-cloudconfig'
```

We just need an absolute path reference to production-cloudconfig.