### PR TITLE
Run THOR in a subprocess

### DIFF
--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -404,8 +404,9 @@ class Worker:
             # Use subprocess.Popen rathen than subprocess.run just so we get a
             # bit more control on output. Doing things carefully lets us stream
             # the process's output through, which lets it appear in logs.
+            cmd = ["python", "-c", script]
             process = subprocess.Popen(
-                ["python", "-c", script],
+                cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
@@ -431,7 +432,7 @@ class Worker:
                 # this is expedient for now.
                 raise subprocess.CalledProcessError(
                     returncode=return_code,
-                    cmd=process.cmd,  # type:ignore
+                    cmd=" ".join(cmd),
                     output=output,
                 )
             else:

--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -1,8 +1,6 @@
 import logging
 import os
 import os.path
-import subprocess
-import sys
 import tempfile
 import time
 from typing import Iterator, Mapping, Optional
@@ -34,6 +32,7 @@ from thorcontrol.taskqueue.tasks import (
     set_task_status,
     upload_job_inputs,
 )
+from thorcontrol.taskqueue.thor_subprocess import run_thor_subprocess
 
 logger = logging.getLogger("thor")
 
@@ -367,81 +366,14 @@ class Worker:
             output_dir = os.path.join(temp_dir.name, "outputs")
             os.makedirs(input_dir, exist_ok=True)
             os.makedirs(output_dir, exist_ok=True)
-            cfg_path, obs_path, orbit_path = download_task_inputs_to_dir(
-                bucket,
-                task,
-                input_dir,
-            )
+            download_task_inputs_to_dir(bucket, task, input_dir)
             logger.debug("downloaded inputs")
 
             logger.info(
                 "beginning execution for job %s, task %s", task.job_id, task.task_id
             )
-            script = f"""
-            import pandas as pd
-            import logging
-            from thor import runTHOR
-            from thor.orbits import Orbits
-            from thor.config import Config
-
-            observations = pd.read_csv(
-                "{obs_path}",
-                index_col=False,
-                dtype={{"obs_id": str}},
-            )
-
-            test_orbits = Orbits.from_csv("{orbit_path}")
-
-            config = Config.fromYaml("{cfg_path}")
-
-            runTHOR(
-                observations,
-                test_orbits,
-                range_shift_config=config.RANGE_SHIFT_CONFIG,
-                cluster_link_config=config.CLUSTER_LINK_CONFIG,
-                iod_config=config.IOD_CONFIG,
-                od_config=config.OD_CONFIG,
-                odp_config=config.ODP_CONFIG,
-                out_dir="{output_dir}",
-                logging_level=logging.INFO,
-            )
-            """
-            # Use subprocess.Popen rathen than subprocess.run just so we get a
-            # bit more control on output. Doing things carefully lets us stream
-            # the process's output through, which lets it appear in logs.
-            cmd = ["python", "-c", script]
-            process = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-
-            # TODO: Would be nice to set a timeout. But it's trickier than it
-            # might appear, if we also want to capture output, since that
-            # blocks on the read call. We need to do something like
-            # select.poll() to get that right.
-
-            output = b""
-            for line in process.stdout:  # type:ignore
-                sys.stdout.write(line.decode("utf8"))
-                output += line
-
-            return_code = process.wait()
-            with open(os.path.join(output_dir, "captured_output.txt"), "wb") as f:
-                f.write(output)
-
-            if return_code != 0:
-                # Slightly roundabout - why not call mark_task_failed, right?
-                # The reason is that mark_task_failed wants an Exception as its
-                # fourth argument. Perhaps that could be refactored out, but
-                # this is expedient for now.
-                raise subprocess.CalledProcessError(
-                    returncode=return_code,
-                    cmd=" ".join(cmd),
-                    output=output,
-                )
-            else:
-                self.mark_task_succeeded(task, bucket, output_dir)
+            run_thor_subprocess(input_dir, output_dir)
+            self.mark_task_succeeded(task, bucket, output_dir)
 
         except Exception as e:
             logger.error("task %s failed", task.task_id, exc_info=e)

--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -373,7 +373,8 @@ class Worker:
             logger.info(
                 "beginning execution for job %s, task %s", task.job_id, task.task_id
             )
-            asyncio.run(run_thor_subprocess(input_dir, output_dir, timeout=60))
+            # TODO: Make this timeout a parameter on the task, or maybe a deadline associated with the Job?
+            asyncio.run(run_thor_subprocess(input_dir, output_dir, timeout=60 * 60 * 4))
             self.mark_task_succeeded(task, bucket, output_dir)
 
         except Exception as e:

--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import os.path
@@ -372,7 +373,7 @@ class Worker:
             logger.info(
                 "beginning execution for job %s, task %s", task.job_id, task.task_id
             )
-            run_thor_subprocess(input_dir, output_dir, timeout=60)
+            asyncio.run(run_thor_subprocess(input_dir, output_dir, timeout=60))
             self.mark_task_succeeded(task, bucket, output_dir)
 
         except Exception as e:

--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -372,7 +372,7 @@ class Worker:
             logger.info(
                 "beginning execution for job %s, task %s", task.job_id, task.task_id
             )
-            run_thor_subprocess(input_dir, output_dir)
+            run_thor_subprocess(input_dir, output_dir, timeout=60)
             self.mark_task_succeeded(task, bucket, output_dir)
 
         except Exception as e:

--- a/thorcontrol/taskqueue/client.py
+++ b/thorcontrol/taskqueue/client.py
@@ -373,34 +373,34 @@ class Worker:
                 "beginning execution for job %s, task %s", task.job_id, task.task_id
             )
             script = f"""
-import pandas as pd
-import logging
-from thor import runTHOR
-from thor.orbits import Orbits
-from thor.config import Config
+            import pandas as pd
+            import logging
+            from thor import runTHOR
+            from thor.orbits import Orbits
+            from thor.config import Config
 
-observations = pd.read_csv(
-    "{observations_file_path}",
-    index_col=False,
-    dtype={{"obs_id": str}},
-)
+            observations = pd.read_csv(
+                "{observations_file_path}",
+                index_col=False,
+                dtype={{"obs_id": str}},
+            )
 
-test_orbits = Orbits.from_csv("{orbits_file_path}")
+            test_orbits = Orbits.from_csv("{orbits_file_path}")
 
-config = Config.fromYaml("{config_file_path}")
+            config = Config.fromYaml("{config_file_path}")
 
-runTHOR(
-    observations,
-    test_orbits,
-    range_shift_config=config.RANGE_SHIFT_CONFIG,
-    cluster_link_config=config.CLUSTER_LINK_CONFIG,
-    iod_config=config.IOD_CONFIG,
-    od_config=config.OD_CONFIG,
-    odp_config=config.ODP_CONFIG,
-    out_dir="{out_dir}",
-    logging_level=logging.INFO,
-)
-"""
+            runTHOR(
+                observations,
+                test_orbits,
+                range_shift_config=config.RANGE_SHIFT_CONFIG,
+                cluster_link_config=config.CLUSTER_LINK_CONFIG,
+                iod_config=config.IOD_CONFIG,
+                od_config=config.OD_CONFIG,
+                odp_config=config.ODP_CONFIG,
+                out_dir="{out_dir}",
+                logging_level=logging.INFO,
+            )
+            """
             # Use subprocess.Popen rathen than subprocess.run just so we get a
             # bit more control on output. Doing things carefully lets us stream
             # the process's output through, which lets it appear in logs.

--- a/thorcontrol/taskqueue/tasks.py
+++ b/thorcontrol/taskqueue/tasks.py
@@ -211,6 +211,29 @@ def new_task_id(orbits: Orbits) -> str:
     return str(uuid.uuid3(_task_id_namespace, combined_ids))
 
 
+def download_task_inputs_to_dir(bucket: Bucket, task: Task, dir: str):
+    cfg_path = _job_input_path(task.job_id, "config.yml")
+    logger.info("downloading task input %s", cfg_path)
+    cfg_bytes = bucket.blob(cfg_path).download_as_bytes()
+
+    with open(os.path.join(dir, "config.yml"), "wb") as f:
+        f.write(cfg_bytes)
+
+    obs_path = _job_input_path(task.job_id, "observations.csv")
+    logger.info("downloading task input %s", obs_path)
+    obs_bytes = bucket.blob(obs_path).download_as_bytes()
+
+    with open(os.path.join(dir, "observations.csv"), "wb") as f:
+        f.write(obs_bytes)
+
+    orbit_path = _task_input_path(task.job_id, task.task_id, "orbit.csv")
+    logger.info("downloading task input %s", orbit_path)
+    orbit_bytes = bucket.blob(orbit_path).download_as_bytes()
+
+    with open(os.path.join(dir, "orbit.csv"), "wb") as f:
+        f.write(orbit_bytes)
+
+
 def download_task_inputs(
     bucket: Bucket, task: Task
 ) -> Tuple[Configuration, pd.DataFrame, Orbits]:

--- a/thorcontrol/taskqueue/tasks.py
+++ b/thorcontrol/taskqueue/tasks.py
@@ -211,7 +211,9 @@ def new_task_id(orbits: Orbits) -> str:
     return str(uuid.uuid3(_task_id_namespace, combined_ids))
 
 
-def download_task_inputs_to_dir(bucket: Bucket, task: Task, dir: str):
+def download_task_inputs_to_dir(
+    bucket: Bucket, task: Task, dir: str
+) -> Tuple[str, str, str]:
     cfg_path = _job_input_path(task.job_id, "config.yml")
     logger.info("downloading task input %s", cfg_path)
     cfg_bytes = bucket.blob(cfg_path).download_as_bytes()
@@ -232,6 +234,8 @@ def download_task_inputs_to_dir(bucket: Bucket, task: Task, dir: str):
 
     with open(os.path.join(dir, "orbit.csv"), "wb") as f:
         f.write(orbit_bytes)
+
+    return (cfg_path, obs_path, orbit_path)
 
 
 def download_task_inputs(

--- a/thorcontrol/taskqueue/tasks.py
+++ b/thorcontrol/taskqueue/tasks.py
@@ -211,9 +211,7 @@ def new_task_id(orbits: Orbits) -> str:
     return str(uuid.uuid3(_task_id_namespace, combined_ids))
 
 
-def download_task_inputs_to_dir(
-    bucket: Bucket, task: Task, dir: str
-) -> Tuple[str, str, str]:
+def download_task_inputs_to_dir(bucket: Bucket, task: Task, dir: str):
     cfg_path = _job_input_path(task.job_id, "config.yml")
     logger.info("downloading task input %s", cfg_path)
     cfg_bytes = bucket.blob(cfg_path).download_as_bytes()
@@ -234,8 +232,6 @@ def download_task_inputs_to_dir(
 
     with open(os.path.join(dir, "orbit.csv"), "wb") as f:
         f.write(orbit_bytes)
-
-    return (cfg_path, obs_path, orbit_path)
 
 
 def download_task_inputs(

--- a/thorcontrol/taskqueue/thor_subprocess.py
+++ b/thorcontrol/taskqueue/thor_subprocess.py
@@ -96,6 +96,7 @@ runTHOR(
     odp_config=config.ODP_CONFIG,
     out_dir="{output_dir}",
     logging_level=logging.INFO,
+    if_exists="erase",
 )
     """
     return ["python", "-c", script]

--- a/thorcontrol/taskqueue/thor_subprocess.py
+++ b/thorcontrol/taskqueue/thor_subprocess.py
@@ -1,0 +1,81 @@
+# Module for running THOR in a subprocess.
+import logging
+import os.path
+import subprocess
+import sys
+from typing import List
+
+logger = logging.getLogger("thor")
+
+
+def run_thor_subprocess(input_dir: str, output_dir: str):
+    cfg_path = os.path.join(input_dir, "config.yml")
+    obs_path = os.path.join(input_dir, "observations.csv")
+    orbit_path = os.path.join(input_dir, "orbit.csv")
+
+    args = _thor_invocation(cfg_path, obs_path, orbit_path, output_dir)
+
+    # Use subprocess.Popen rathen than subprocess.run just so we get a
+    # bit more control on output. Doing things carefully lets us stream
+    # the process's output through, which lets it appear in logs.
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # TODO: Would be nice to set a timeout. But it's trickier than it
+    # might appear, if we also want to capture output, since that
+    # blocks on the read call. We need to do something like
+    # select.poll() to get that right.
+
+    output = b""
+    for line in process.stdout:  # type:ignore
+        sys.stdout.write(line.decode("utf8"))
+        output += line
+
+    return_code = process.wait()
+    with open(os.path.join(output_dir, "captured_output.txt"), "wb") as f:
+        f.write(output)
+
+    if return_code != 0:
+        raise THORExecutionFailure()
+
+
+def _thor_invocation(
+    cfg_path: str, obs_path: str, orbit_path: str, output_dir: str
+) -> List[str]:
+    """
+    Returns the command line arguments used to run THOR.
+    """
+    script = f"""
+    import pandas as pd
+    import logging
+    from thor import runTHOR
+    from thor.orbits import Orbits
+    from thor.config import Config
+
+    observations = pd.read_csv(
+        "{obs_path}",
+        index_col=False,
+        dtype={{"obs_id": str}},
+    )
+
+    test_orbits = Orbits.from_csv("{orbit_path}")
+
+    config = Config.fromYaml("{cfg_path}")
+
+    runTHOR(
+        observations,
+        test_orbits,
+        range_shift_config=config.RANGE_SHIFT_CONFIG,
+        cluster_link_config=config.CLUSTER_LINK_CONFIG,
+        iod_config=config.IOD_CONFIG,
+        od_config=config.OD_CONFIG,
+        odp_config=config.ODP_CONFIG,
+        out_dir="{output_dir}",
+        logging_level=logging.INFO,
+    )
+    """
+    return ["python", "-c", script]
+
+
+class THORExecutionFailure(Exception):
+    def __init__(self):
+        pass

--- a/thorcontrol/taskqueue/thor_subprocess.py
+++ b/thorcontrol/taskqueue/thor_subprocess.py
@@ -69,33 +69,33 @@ def _thor_invocation(
     Returns the command line arguments used to run THOR.
     """
     script = f"""
-    import pandas as pd
-    import logging
-    from thor import runTHOR
-    from thor.orbits import Orbits
-    from thor.config import Config
+import pandas as pd
+import logging
+from thor import runTHOR
+from thor.orbits import Orbits
+from thor.config import Config
 
-    observations = pd.read_csv(
-        "{obs_path}",
-        index_col=False,
-        dtype={{"obs_id": str}},
-    )
+observations = pd.read_csv(
+    "{obs_path}",
+    index_col=False,
+    dtype={{"obs_id": str}},
+)
 
-    test_orbits = Orbits.from_csv("{orbit_path}")
+test_orbits = Orbits.from_csv("{orbit_path}")
 
-    config = Config.fromYaml("{cfg_path}")
+config = Config.fromYaml("{cfg_path}")
 
-    runTHOR(
-        observations,
-        test_orbits,
-        range_shift_config=config.RANGE_SHIFT_CONFIG,
-        cluster_link_config=config.CLUSTER_LINK_CONFIG,
-        iod_config=config.IOD_CONFIG,
-        od_config=config.OD_CONFIG,
-        odp_config=config.ODP_CONFIG,
-        out_dir="{output_dir}",
-        logging_level=logging.INFO,
-    )
+runTHOR(
+    observations,
+    test_orbits,
+    range_shift_config=config.RANGE_SHIFT_CONFIG,
+    cluster_link_config=config.CLUSTER_LINK_CONFIG,
+    iod_config=config.IOD_CONFIG,
+    od_config=config.OD_CONFIG,
+    odp_config=config.ODP_CONFIG,
+    out_dir="{output_dir}",
+    logging_level=logging.INFO,
+)
     """
     return ["python", "-c", script]
 

--- a/thorcontrol/taskqueue/thor_subprocess.py
+++ b/thorcontrol/taskqueue/thor_subprocess.py
@@ -72,7 +72,7 @@ def _thor_invocation(
     script = f"""
 import pandas as pd
 import logging
-from thor import runTHOR
+from thor.main import runTHOROrbit
 from thor.orbits import Orbits
 from thor.config import Config
 
@@ -86,7 +86,7 @@ test_orbits = Orbits.from_csv("{orbit_path}")
 
 config = Config.fromYaml("{cfg_path}")
 
-runTHOR(
+runTHOROrbit(
     observations,
     test_orbits,
     range_shift_config=config.RANGE_SHIFT_CONFIG,


### PR DESCRIPTION
Fixes #15 

This changes thorctl to run THOR as a subprocess of the worker, rather than calling Python functions directly.

This gives us a bit of process-level separation, in case THOR goes off and fails in a spectacular way: if it segfaults, or runs out of memory, or gets in an infinite loop, we're protected.

Also, it protects us a bit from the Python google-api-core library's incompatibility with multiprocessing.

---

The code currently literally calls a Python script. When https://github.com/moeyensj/thor/issues/82 gets resolved, this could be improved.