### PR TITLE
Use c2-standard-16 instances to run thor workers

### DIFF
--- a/infra/autoscaler/production-cloudconfig
+++ b/infra/autoscaler/production-cloudconfig
@@ -24,7 +24,12 @@ write_files:
                         --net=host \
                         --env THOR_AUTOSCALED_QUEUES=production-tasks \
                         gcr.io/moeyens-thor-dev/thorctl:production-tasks-latest \
-                        thorctl autoscale --rabbit-password-from-secret-manager production-tasks
+                        thorctl autoscale \
+                            --rabbit-password-from-secret-manager \
+                            --machine-type c2-standard-16 \
+                            production-tasks
+
+
     ExecStop=/usr/bin/docker stop thor-autoscaler
     ExecStopPost=/usr/bin/docker rm thor-autoscaler
 


### PR DESCRIPTION
The maximum number of workers remains 16, but switching from `e2-standard-8` to `c2-standard-16` should significantly boots our throughput.

These changes will only take effect once the production worker pool has scaled down because of idle-ness, and since only *new* workers will have this instance type.

cc @KatKiker 