### PR TITLE
Enable gcplogs log driver to persist logs

### DIFF
--- a/thorcontrol/bin/thorctl/worker_pool.py
+++ b/thorcontrol/bin/thorctl/worker_pool.py
@@ -103,6 +103,7 @@ write_files:
     ExecStart=/usr/bin/docker run --rm \
                         --name thor-worker \
                         --net=host \
+                        --log-driver=gcplogs \
                         gcr.io/moeyens-thor-dev/thorctl:{self.queue_name}-latest \
                         run-thor-worker {self.queue_name} --rabbit-password-from-secret-manager
     ExecStop=/usr/bin/docker stop thor-worker


### PR DESCRIPTION
This will let logs get automatically sent to GCP's log storage for indexing and viewing.