### PR TITLE
Pin Google Cloud SDK action to major version v0, update THOR cloning protocol to use https

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         docker build -t thorctl:${{ github.sha }} .
 
     - name: Set up cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
     - name: Set up cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
     - name: Set up cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
         pip install .
 
     - name: Set up cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,98 +4,93 @@
 #
 #    pip-compile dev-requirements.in
 #
-attrs==21.2.0
+attrs==22.1.0
     # via pytest
-backports.entry-points-selectable==1.1.0
-    # via virtualenv
-black==21.9b0
+black==22.8.0
     # via -r dev-requirements.in
+build==0.8.0
+    # via pip-tools
 cfgv==3.3.1
     # via pre-commit
-click==8.0.1
+click==8.1.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.2
+distlib==0.3.6
     # via virtualenv
-filelock==3.0.12
+filelock==3.8.0
     # via virtualenv
-flake8==3.9.2
+flake8==5.0.4
     # via -r dev-requirements.in
-identify==2.2.14
+identify==2.5.5
     # via pre-commit
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
+isort==5.10.1
     # via -r dev-requirements.in
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
-mypy==0.910
+mypy==0.971
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-packaging==21.0
-    # via pytest
-pathspec==0.9.0
+packaging==21.3
+    # via
+    #   build
+    #   pytest
+pathspec==0.10.1
     # via black
-pep517==0.11.0
-    # via pip-tools
-pip-tools==6.2.0
+pep517==0.13.0
+    # via build
+pip-tools==6.8.0
     # via -r dev-requirements.in
-platformdirs==2.3.0
+platformdirs==2.5.2
     # via
     #   black
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.15.0
+pre-commit==2.20.0
     # via -r dev-requirements.in
-py==1.10.0
+py==1.11.0
     # via pytest
-pycodestyle==2.7.0
+pycodestyle==2.9.1
     # via flake8
-pyflakes==2.3.1
+pyflakes==2.5.0
     # via flake8
-pyparsing==2.4.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.3
     # via -r dev-requirements.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via pre-commit
-regex==2021.8.28
-    # via black
-six==1.16.0
-    # via virtualenv
 toml==0.10.2
-    # via
-    #   mypy
-    #   pre-commit
-    #   pytest
-tomli==1.2.1
-    # via
-    #   black
-    #   pep517
-types-cryptography==3.3.5
-    # via types-paramiko
-types-enum34==1.1.0
-    # via types-cryptography
-types-ipaddress==1.0.0
-    # via types-cryptography
-types-paramiko==0.1.9
-    # via -r dev-requirements.in
-types-requests==2.25.6
-    # via -r dev-requirements.in
-typing-extensions==3.10.0.2
-    # via
-    #   black
-    #   mypy
-virtualenv==20.8.0
     # via pre-commit
-wheel==0.37.0
+tomli==2.0.1
+    # via
+    #   black
+    #   build
+    #   mypy
+    #   pytest
+types-cryptography==3.3.23
+    # via types-paramiko
+types-paramiko==2.11.5
+    # via -r dev-requirements.in
+types-requests==2.28.10
+    # via -r dev-requirements.in
+types-urllib3==1.26.24
+    # via types-requests
+typing-extensions==4.3.0
+    # via
+    #   black
+    #   mypy
+virtualenv==20.16.5
+    # via pre-commit
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # THOR:
-git+git://github.com/moeyensj/thor@e24ec5f297349d68840c0ce1bf0d17f92c3c4869#egg=thor
+git+https://github.com/moeyensj/thor@e24ec5f297349d68840c0ce1bf0d17f92c3c4869#egg=thor
 
 pika
 google-cloud-storage>=1.39.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,62 +4,64 @@
 #
 #    pip-compile requirements.in
 #
-astropy==4.3.1
+astropy==5.1
     # via
     #   astroquery
     #   healpy
     #   pyvo
     #   thor
-astroquery==0.4.3
+astroquery==0.4.6
     # via thor
+asttokens==2.0.8
+    # via stack-data
 backcall==0.2.0
     # via ipython
-bcrypt==3.2.0
+bcrypt==4.0.0
     # via paramiko
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
     # via astroquery
-cachetools==4.2.2
+cachetools==5.2.0
     # via google-auth
-certifi==2021.5.30
+certifi==2022.6.15
     # via requests
-cffi==1.14.6
+cffi==1.15.1
     # via
-    #   bcrypt
     #   cryptography
-    #   google-crc32c
     #   pynacl
-charset-normalizer==2.0.5
+charset-normalizer==2.1.1
     # via requests
-colorama==0.4.4
-    # via
-    #   -r requirements.in
-    #   rich
+colorama==0.4.5
+    # via -r requirements.in
 commonmark==0.9.1
     # via rich
-cryptography==3.4.8
+cryptography==38.0.1
     # via
     #   paramiko
     #   secretstorage
-cycler==0.10.0
+cycler==0.11.0
     # via matplotlib
-debugpy==1.4.3
+debugpy==1.6.3
     # via ipykernel
-decorator==5.1.0
+decorator==5.1.1
     # via ipython
 difi==1.1
     # via thor
-entrypoints==0.3
+entrypoints==0.4
     # via jupyter-client
-google-api-core[grpc]==2.0.1
+executing==1.0.0
+    # via stack-data
+fonttools==4.37.1
+    # via matplotlib
+google-api-core[grpc]==2.10.0
     # via
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-api-python-client==2.21.0
+google-api-python-client==2.60.0
     # via -r requirements.in
-google-auth==2.1.0
+google-auth==2.11.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -68,92 +70,96 @@ google-auth==2.1.0
     #   google-cloud-storage
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-google-cloud-core==2.0.0
+google-cloud-core==2.3.2
     # via google-cloud-storage
-google-cloud-pubsub==2.8.0
+google-cloud-pubsub==2.13.6
     # via -r requirements.in
-google-cloud-secret-manager==2.7.1
+google-cloud-secret-manager==2.12.4
     # via -r requirements.in
-google-cloud-storage==1.42.1
+google-cloud-storage==2.5.0
     # via -r requirements.in
-google-crc32c==1.1.2
+google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.0.2
+google-resumable-media==2.3.3
     # via google-cloud-storage
-googleapis-common-protos[grpc]==1.53.0
+googleapis-common-protos[grpc]==1.56.4
     # via
     #   google-api-core
     #   grpc-google-iam-v1
-grpc-google-iam-v1==0.12.3
+    #   grpcio-status
+grpc-google-iam-v1==0.12.4
     # via
     #   google-cloud-pubsub
     #   google-cloud-secret-manager
-grpcio==1.40.0
+grpcio==1.48.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
-healpy==1.15.0
+    #   grpcio-status
+grpcio-status==1.48.1
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
+healpy==1.16.1
     # via thor
 html5lib==1.1
     # via astroquery
-httplib2==0.19.1
+httplib2==0.20.4
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.2
+idna==3.3
     # via requests
-importlib-metadata==4.8.1
-    # via keyring
-ipykernel==6.4.1
+importlib-metadata==4.12.0
+    # via
+    #   keyring
+    #   numba
+ipykernel==6.15.2
     # via thor
-ipython==7.27.0
+ipython==8.5.0
     # via ipykernel
-ipython-genutils==0.2.0
-    # via ipykernel
-jedi==0.18.0
+jaraco.classes==3.2.2
+    # via keyring
+jedi==0.18.1
     # via ipython
-jeepney==0.7.1
+jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-joblib==1.0.1
+joblib==1.1.0
     # via scikit-learn
-jupyter-client==7.0.3
+jupyter-client==7.3.5
     # via ipykernel
-jupyter-core==4.7.1
+jupyter-core==4.11.1
     # via jupyter-client
-keyring==23.2.1
+keyring==23.9.1
     # via astroquery
-kiwisolver==1.3.2
+kiwisolver==1.4.4
     # via matplotlib
-libcst==0.3.20
-    # via
-    #   google-cloud-pubsub
-    #   google-cloud-secret-manager
-llvmlite==0.37.0
+llvmlite==0.39.1
     # via numba
-matplotlib==3.4.3
+matplotlib==3.5.3
     # via
     #   healpy
     #   seaborn
     #   thor
-matplotlib-inline==0.1.3
+matplotlib-inline==0.1.6
     # via
     #   ipykernel
     #   ipython
-mimeparse==0.1.3
-    # via pyvo
-mypy-extensions==0.4.3
-    # via typing-inspect
-nest-asyncio==1.5.1
-    # via jupyter-client
-numba==0.54.0
+more-itertools==8.14.0
+    # via jaraco.classes
+nest-asyncio==1.5.5
+    # via
+    #   ipykernel
+    #   jupyter-client
+numba==0.56.2
     # via thor
-numexpr==2.7.3
+numexpr==2.8.3
     # via tables
-numpy==1.20.3
+numpy==1.23.2
     # via
     #   astropy
     #   astroquery
@@ -170,59 +176,69 @@ numpy==1.20.3
     #   spiceypy
     #   tables
     #   thor
-packaging==21.0
+packaging==21.3
     # via
-    #   google-cloud-pubsub
-    #   google-cloud-secret-manager
-pandas==1.3.3
+    #   astropy
+    #   ipykernel
+    #   matplotlib
+    #   numexpr
+    #   tables
+pandas==1.4.4
     # via
     #   difi
     #   seaborn
     #   thor
-paramiko==2.7.2
+paramiko==2.11.0
     # via -r requirements.in
-parso==0.8.2
+parso==0.8.3
     # via jedi
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pika==1.2.0
+pika==1.3.0
     # via -r requirements.in
-pillow==8.3.2
+pillow==9.2.0
     # via matplotlib
-plotly==5.3.1
+plotly==5.10.0
     # via thor
-prompt-toolkit==3.0.20
+prompt-toolkit==3.0.31
     # via ipython
-proto-plus==1.19.0
+proto-plus==1.22.1
     # via
     #   google-cloud-pubsub
     #   google-cloud-secret-manager
-protobuf==3.18.0
+protobuf==4.21.5
     # via
     #   google-api-core
+    #   google-cloud-pubsub
+    #   google-cloud-secret-manager
     #   googleapis-common-protos
+    #   grpcio-status
     #   proto-plus
+psutil==5.9.2
+    # via ipykernel
 ptyprocess==0.7.0
     # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pyerfa==2.0.0
+pyerfa==2.0.0.1
     # via astropy
-pygments==2.10.0
+pygments==2.13.0
     # via
     #   ipython
     #   rich
-pynacl==1.4.0
+pynacl==1.5.0
     # via paramiko
-pyparsing==2.4.7
+pyparsing==3.0.9
     # via
     #   httplib2
     #   matplotlib
@@ -232,87 +248,83 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   matplotlib
     #   pandas
-pytz==2021.1
+pytz==2022.2.1
     # via pandas
-pyvo==1.1
+pyvo==1.3
     # via astroquery
-pyyaml==5.4.1
+pyyaml==6.0
     # via
-    #   libcst
+    #   astropy
     #   thor
-pyzmq==22.3.0
-    # via jupyter-client
-requests==2.26.0
+pyzmq==23.2.1
+    # via
+    #   ipykernel
+    #   jupyter-client
+requests==2.28.1
     # via
     #   astroquery
     #   google-api-core
     #   google-cloud-storage
     #   pyvo
-rich==10.9.0
+rich==12.5.1
     # via -r requirements.in
-rsa==4.7.2
+rsa==4.9
     # via google-auth
-scikit-learn==0.24.2
+scikit-learn==1.1.2
     # via thor
-scipy==1.7.1
+scipy==1.9.1
     # via
     #   healpy
     #   scikit-learn
-    #   seaborn
     #   thor
-seaborn==0.11.2
+seaborn==0.12.0
     # via thor
-secretstorage==3.3.1
+secretstorage==3.3.3
     # via keyring
 six==1.16.0
     # via
-    #   astroquery
-    #   bcrypt
-    #   cycler
+    #   google-auth
     #   google-auth-httplib2
     #   grpcio
     #   html5lib
-    #   plotly
-    #   pynacl
+    #   paramiko
     #   python-dateutil
-soupsieve==2.2.1
+soupsieve==2.3.2.post1
     # via beautifulsoup4
-spiceypy==4.0.2
+spiceypy==5.1.1
     # via thor
-tables==3.6.1
+stack-data==0.5.0
+    # via ipython
+tables==3.7.0
     # via thor
 tenacity==8.0.1
     # via plotly
-git+git://github.com/moeyensj/thor@e24ec5f297349d68840c0ce1bf0d17f92c3c4869#egg=thor
+git+https://github.com/moeyensj/thor@e24ec5f297349d68840c0ce1bf0d17f92c3c4869#egg=thor
     # via -r requirements.in
-threadpoolctl==2.2.0
+threadpoolctl==3.1.0
     # via scikit-learn
-tornado==6.1
+tornado==6.2
     # via
     #   ipykernel
     #   jupyter-client
-traitlets==5.1.0
+traitlets==5.3.0
     # via
     #   ipykernel
     #   ipython
     #   jupyter-client
     #   jupyter-core
     #   matplotlib-inline
-typing-extensions==3.10.0.2
-    # via
-    #   libcst
-    #   typing-inspect
-typing-inspect==0.7.1
-    # via libcst
-uritemplate==3.0.1
+typing-extensions==4.3.0
+    # via rich
+uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.6
+urllib3==1.26.12
     # via requests
 wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-zipp==3.5.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Quick fix for deprecated "master" version of the Google Cloud SDK action. Pip installing the THOR code using the git+git protocol seemed to unreliably timeout, so instead swap to using git+https. Lastly, update the requirements to take into account nearly 12 months of updates to dependencies. 